### PR TITLE
Fix nonmatching macro assembly errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ endif
 OPTFLAGS        := -O2
 
 ASFLAGS         := -march=vr4300 -32 $(IINC)
-AS_DEFINES      := -DMIPSEB -D_LANGUAGE_ASSEMBLY -D_ULTRA64
+AS_DEFINES := -DMIPSEB -D_LANGUAGE_ASSEMBLY -D_ULTRA64 -D'nonmatching(...)=' -D'enddlabel(...)='
 MIPS_VERSION    := -mips3
 
 # Surpress the warnings with -woff.

--- a/include/include_asm.h
+++ b/include/include_asm.h
@@ -12,7 +12,6 @@
         "\t.globl\t"#NAME"\n" \
         "\t.type "#NAME", @function\n" \
         "\t.ent\t"#NAME"\n" \
-        #NAME ":\n" \
         "\t.include \""FOLDER"/"#NAME".s\"\n" \
         "\t.set reorder\n" \
         "\t.set at\n" \
@@ -22,6 +21,7 @@
     );
 #endif
 __asm__(".include \"include/labels.inc\"\n");
+__asm__(".include \"include/macro.inc\"\n");
 #else
 #define INCLUDE_ASM(FOLDER, NAME)
 #endif

--- a/include/macro.inc
+++ b/include/macro.inc
@@ -1,4 +1,4 @@
-.include "labels.inc"
+.include "include/labels.inc"
 
 # COP0 register aliases
 
@@ -73,3 +73,10 @@
 
 #define nonmatching(...)
 #define enddlabel(...)
+
+.macro nonmatching name, size
+.space \size
+.endm
+
+.macro enddlabel name
+.endm


### PR DESCRIPTION
- Add GAS .macro definitions for nonmatching and enddlabel to macro.inc
- Fix .include path for labels.inc to use full relative path
- Add .include of macro.inc to include_asm.h so INCLUDE_ASM finds macros
- Change .skip to .space for MIPS GAS compatibility