### PR TITLE
Fix assembly pipeline and match first function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ permuter_settings.toml
 # Makefile options
 .make_options
 
+
+# decomp-permuter - cloned separately, not a submodule
+tools/decomp-permuter/

--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,7 @@ setup:
 extract:
 	$(RM) -r asm bin
 	$(SPLAT) $(SPLAT_YAML)
+	python3 tools/fix_gas_pc16_bug.py
 
 lib:
 	$(MAKE) -C lib
@@ -232,7 +233,7 @@ $(BUILD_DIR)/%.o: %.bin
 	$(OBJCOPY) -I binary -O elf32-big $< $@
 
 $(BUILD_DIR)/%.o: %.s
-	$(CPP) $(CPPFLAGS) $(IINC) $(AS_DEFINES) $(IINC) $< | $(AS) $(ASFLAGS) -o $@
+	(grep -q '\.include "macro.inc"' $< || echo '.include "macro.inc"'; cat $<) | $(CPP) $(CPPFLAGS) $(IINC) $(AS_DEFINES) - | cat include/gas_macros.inc - | $(AS) $(ASFLAGS) -o $@
 	$(OBJDUMP_CMD)
 
 $(BUILD_DIR)/%.o: %.c

--- a/include/gas_macros.inc
+++ b/include/gas_macros.inc
@@ -1,0 +1,6 @@
+.macro nonmatching name, size
+.space \size
+.endm
+
+.macro enddlabel name
+.endm

--- a/include/include_asm.h
+++ b/include/include_asm.h
@@ -5,20 +5,17 @@
 #ifndef INCLUDE_ASM
 #define INCLUDE_ASM(FOLDER, NAME) \
    __asm__( \
-        ".section .text\n" \
         "\t.set noat\n" \
         "\t.set noreorder\n" \
-        "\t.align\t2\n" \
         "\t.globl\t"#NAME"\n" \
         "\t.type "#NAME", @function\n" \
         "\t.ent\t"#NAME"\n" \
-        #NAME ":\n" \
+        #NAME":\n" \
         "\t.include \""FOLDER"/"#NAME".s\"\n" \
         "\t.set reorder\n" \
         "\t.set at\n" \
         "\t.end\t"#NAME"\n" \
-        ".end"#NAME":\n" \
-        "\t.size\t"#NAME",.end"#NAME"-"#NAME \
+        "\t.size\t"#NAME",.-"#NAME \
     );
 #endif
 __asm__(".include \"include/labels.inc\"\n");

--- a/include/labels.inc
+++ b/include/labels.inc
@@ -2,3 +2,5 @@
     .global \label
     \label:
 .endm
+
+

--- a/mariogolf64.yaml
+++ b/mariogolf64.yaml
@@ -32,6 +32,7 @@ options:
     #include "ultra64.h"
     #include "include_asm.h"
   asm_inc_header: ""
+  include_macro_inc: False
   use_legacy_include_asm: False
   mips_abi_float_regs: o32
   mnemonic_ljust: 11
@@ -68,7 +69,6 @@ segments:
     type: code
     start: 0x1050
     vram: 0x80025C50
-    follows_vram: entry
     bss_size: 0x122100
     subsegments:
       - [0x1050, asm, nusys/nupireadrom]

--- a/src/overlay_manager.c
+++ b/src/overlay_manager.c
@@ -39,7 +39,11 @@ void func_80025D30(void)
 }
 
 /* Constructor of overlay #6 */
-INCLUDE_ASM("asm/nonmatchings/overlay_manager", func_80025D54);
+/* Constructor of overlay #6 */
+void func_80025D54(void) {
+    func_802033B0();
+    func_801F5018();
+}
 
 s32 func_80025D78(s32 index)
 {

--- a/tools/fix_gas_pc16_bug.py
+++ b/tools/fix_gas_pc16_bug.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+fix_gas_pc16_bug.py - Workaround for GNU Binutils R_MIPS_PC16 relocation bug
+
+Bug description:
+    When a branch instruction targets a global symbol (declared via .global or
+    glabel) in the same section, mips-linux-gnu-as (GNU Binutils 2.42) emits an
+    R_MIPS_PC16 relocation and defers resolution to the linker. The linker's
+    R_MIPS_PC16 handler then computes the branch offset incorrectly, producing
+    a branch that targets the wrong address.
+
+    When a branch targets a local (non-global) symbol, GAS resolves the offset
+    directly at assembly time with no relocation record, and the result is correct.
+
+Root cause:
+    Confirmed via objdump -r: global symbol branches emit R_MIPS_PC16 relocations,
+    local symbol branches do not. The linker's R_MIPS_PC16 calculation is wrong
+    for same-section references.
+
+    Minimal reproducer:
+        .global test_func    # With this: bnez encodes as 1440ffff (wrong)
+        test_func:           # Without:   bnez encodes as 1440fffd (correct)
+            nop
+            nop
+            bnez $v0, test_func
+            nop
+
+Workaround:
+    Replace branch targets that reference global symbols with local labels.
+    Local labels bypass the R_MIPS_PC16 relocation path entirely.
+
+Files patched and why:
+    asm/nusys/nugfxtaskallendwait.s:
+        nuGfxTaskAllEndWait is a tight self-referencing loop. The branch target
+        is replaced with local label .L800A1600 at the top of the loop.
+"""
+
+from pathlib import Path
+
+PATCHES = [
+    {
+        "file": "asm/nusys/nugfxtaskallendwait.s",
+        "description": "Replace self-referencing branch to global nuGfxTaskAllEndWait with local label",
+        "add_after": "glabel nuGfxTaskAllEndWait",
+        "add_line": ".L800A1600:",
+        "replace": {
+            "bnez       $v0, nuGfxTaskAllEndWait": "bnez       $v0, .L800A1600",
+        },
+    },
+]
+
+def apply_patches():
+    for patch in PATCHES:
+        path = Path(patch["file"])
+        if not path.exists():
+            print(f"WARNING: {path} does not exist, skipping")
+            continue
+
+        content = path.read_text()
+
+        # Check if already patched by looking for the add_line
+        if "add_line" in patch and patch["add_line"] in content:
+            print(f"Already patched: {path}")
+            continue
+
+        lines = content.splitlines(keepends=True)
+        out = []
+        changed = False
+
+        for line in lines:
+            stripped = line.strip()
+
+            # Add local label after specified line
+            if "add_after" in patch and stripped == patch["add_after"]:
+                out.append(line)
+                out.append(patch["add_line"] + "\n")
+                changed = True
+                continue
+
+            # Apply replacements
+            new_line = line
+            for old, new in patch.get("replace", {}).items():
+                if old in line:
+                    new_line = line.replace(old, new)
+                    changed = True
+            out.append(new_line)
+
+        if changed:
+            path.write_text("".join(out))
+            print(f"Patched: {path} - {patch['description']}")
+        else:
+            print(f"No match found: {path}")
+
+if __name__ == "__main__":
+    apply_patches()
+    print("Done")

--- a/tools/splat/disassembler/spimdisasm_disassembler.py
+++ b/tools/splat/disassembler/spimdisasm_disassembler.py
@@ -16,6 +16,7 @@ class SpimdisasmDisassembler(disassembler.Disassembler):
         spimdisasm.common.GlobalConfig.TRUST_USER_FUNCTIONS = True
         spimdisasm.common.GlobalConfig.TRUST_JAL_FUNCTIONS = True
         spimdisasm.common.GlobalConfig.GLABEL_ASM_COUNT = False
+        spimdisasm.common.GlobalConfig.ASM_NM_LABEL = ""
 
         if opts.rom_address_padding:
             spimdisasm.common.GlobalConfig.ASM_COMMENT_OFFSET_WIDTH = 6


### PR DESCRIPTION
Infrastructure fixes:
- Fix INCLUDE_ASM .size calculation: replace synthetic end label with '.- NAME' syntax. Previous approach caused every INCLUDE_ASM function to appear oversized by exactly the next function's size, producing 158KB of drift across the entire binary and all linker errors.
- Fix duplicate macro.inc include in Makefile .s rule: conditionally prepend only for files that don't already self-include it.
- Fix segment layout: remove follows_vram from main segment so explicit vram address is used correctly.
- Disable spimdisasm ASM_NM_LABEL: standalone .s files now generate clean traditional assembly without nonmatching wrappers.
- Remove dead code: strip_nonmatching.py, strip_glabel.py, and inline nonmatching/enddlabel __asm__ definitions were all confirmed no-ops.
- Add tools/fix_gas_pc16_bug.py: workaround for GNU Binutils 2.42 bug where PC-relative branches to global symbols produce wrong encodings due to incorrect R_MIPS_PC16 linker relocation handling. Runs automatically on make extract, currently patches nugfxtaskallendwait.s.
- Remove decomp-permuter from git index: cloned separately, not a submodule.

Result: zero drift, zero linker errors, ROM MD5 matches original.

Decompilation:
- Match func_80025D54 in overlay_manager.c: simple constructor calling func_802033B0 and func_801F5018. overlay_manager.c now has zero stubs.